### PR TITLE
Updated default Dalle size image configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ DALLE_ENABLED=False
 DALLE_ICON_PREFIX=🎨
 DALLE_USE_3=False
 # See all supported sizes here https://platform.openai.com/docs/api-reference/images/create#images-create-size
-DALLE_SIZE=512x512
+DALLE_SIZE=1024x1024
 
 # # Google Gemini
 GEMINI_PREFIX=!gemini


### PR DESCRIPTION
The default size for the Dalle configuration has been changed, this allows it to be generated with the Dalle 2 and Dalle 3 versions.