### PR TITLE
Fixed skipPrefix for selfMessage

### DIFF
--- a/src/baileys/handlers/message.ts
+++ b/src/baileys/handlers/message.ts
@@ -32,7 +32,10 @@ if (ENV.DALLE_ENABLED && ENV.OPENAI_ENABLED) {
 
 // handles message
 export async function handleMessage({ client, msg, metadata }: MessageHandlerParams) {
-  const modelInfo: ModelByPrefix | undefined = Util.getModelByPrefix(metadata.text);
+  const modelInfo: ModelByPrefix | undefined = Util.getModelByPrefix(
+    metadata.text,
+    metadata.fromMe
+  );
   if (!modelInfo) {
     if (ENV.Debug) {
       console.log("[Debug] Model '" + modelInfo + "' not found");

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -5,8 +5,17 @@ import config from '../whatsapp-ai.config';
 
 export class Util {
   public static getModelByPrefix(
-    message: string
+    message: string,
+    fromMe: Boolean
   ): { modelName: AIModels; prefix: string } | undefined {
+    if (fromMe) {
+      const defaultModelName = config.prefix.defaultModel;
+      const defaultModel = config.models[defaultModelName];
+      if (defaultModel && defaultModel.enable) {
+        return { modelName: defaultModelName as AIModels, prefix: defaultModel.prefix as string };
+      }
+    }
+
     for (let [modelName, model] of Object.entries(config.models)) {
       const currentModel = model as IModelConfig;
       if (!currentModel.enable) continue;


### PR DESCRIPTION
When skipPrefix for selfMessage in the config is enabled, the bot cannot detect what model to use, since it takes it from the prefix.

I have made a small modification so it takes the model from config.prefix.defaultModel